### PR TITLE
feat: 3조 Method 권한처리 요구사항 작업 완료

### DIFF
--- a/src/main/java/KKSC/page/domain/calendar/repoAndService/EventService.java
+++ b/src/main/java/KKSC/page/domain/calendar/repoAndService/EventService.java
@@ -1,27 +1,34 @@
 package KKSC.page.domain.calendar.repoAndService;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 
 @Service
 public interface EventService {
     
-    // 일정 목록 조회    
+    // 일정 목록 조회
+    @PreAuthorize("hasRole('permission_level1 ')")
     Long getScheduleList();
 
     // 일정 생성
+    @PreAuthorize("hasRole('permission_level0 ')")
     Long createSchedule();
 
     // 일정 삭제
+    @PreAuthorize("hasRole('permission_level0 ')")
     Long deleteSchedule();
 
     // 일정 수정
+    @PreAuthorize("hasRole('permission_level0 ')")
     Long updateSchedule();
 
     // 일정 참가
+    @PreAuthorize("hasRole('permission_level1 ')")
     Long joinSchedule();
 
     // 일정 참가 취소
+    @PreAuthorize("hasRole('permission_level1 ')")
     Long cancelSchedule ();
 
 }

--- a/src/main/java/KKSC/page/domain/member/entity/Permission.java
+++ b/src/main/java/KKSC/page/domain/member/entity/Permission.java
@@ -3,9 +3,25 @@ package KKSC.page.domain.member.entity;
 public enum Permission {
 
     //관리자
-    permission_level0,
+    permission_level0("ROLE_PERMISSION_LEVEL0", "관리자"),
     //일반회원
-    permission_level1,
+    permission_level1("ROLE_PERMISSION_LEVEL1", "정회원"),
     //준회원
-    permission_level2
+    permission_level2("ROLE_PERMISSION_LEVEL2", "준회원");
+
+    private final String roleName;
+    private final String description;
+
+    Permission(String roleName, String description) {
+        this.roleName = roleName;
+        this.description = description;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/KKSC/page/domain/notice/service/NoticeBoardService.java
+++ b/src/main/java/KKSC/page/domain/notice/service/NoticeBoardService.java
@@ -7,19 +7,25 @@ import KKSC.page.domain.notice.entity.Keyword;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 public interface NoticeBoardService {
-
+    @PreAuthorize("hasRole('permission_level0 ')")
     Long create(NoticeBoardRequest noticeBoardRequest, String memberName);
 
+    @PreAuthorize("hasRole('permission_level0 ')")
     NoticeBoardDetailResponse update(Long noticeBoardId, NoticeBoardRequest noticeBoardRequest);
 
+    @PreAuthorize("hasRole('permission_level0 ')")
     void delete(Long noticeBoardId);
 
+    @PreAuthorize("hasRole('permission_level1 ')")
     Page<NoticeBoardListResponse> getBoardList(Pageable pageable); /* 기본적으로 보여줄 게시글 목록 */
 
+    @PreAuthorize("hasRole('permission_level1 ')")
     NoticeBoardDetailResponse getBoardDetail(Long noticeBoardId); /* 글 선택 시 보여줄 상세 글 */
 
+    @PreAuthorize("hasRole('permission_level1 ')")
     Page<NoticeBoardListResponse> searchBoardList(Keyword keyword, String query, Pageable pageable); /* 작성일 순, 작성자가 포함된 글 불러오기 */
 
     void countUpView(Long noticeBoardId);

--- a/src/main/java/KKSC/page/domain/notice/service/NoticeFileService.java
+++ b/src/main/java/KKSC/page/domain/notice/service/NoticeFileService.java
@@ -1,6 +1,7 @@
 package KKSC.page.domain.notice.service;
 
 import org.springframework.core.io.Resource;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 public interface NoticeFileService {
@@ -11,6 +12,7 @@ public interface NoticeFileService {
 	 * @return 미정
 	 * @since 2024.07.06
 	 */
+	@PreAuthorize("hasRole('permission_level0 ')")
 	String uploadFile(MultipartHttpServletRequest uploadRequestFile, Long noticeBoardId) throws Exception;
 
 	/**
@@ -19,6 +21,7 @@ public interface NoticeFileService {
 	 * @return 미정
 	 * @since 2024.07.06
 	 */
+	@PreAuthorize("hasRole('permission_level0 ')")
 	Resource downloadFile(Long noticeFileId);
 
 	/**
@@ -27,6 +30,7 @@ public interface NoticeFileService {
 	 * @return 미정
 	 * @since 2024.07.06
 	 */
+	@PreAuthorize("hasRole('permission_level0 ')")
 	String deleteFile(Long noticeFileId);
 }
 


### PR DESCRIPTION
NoticeBoardService.java
Admin->create, update, delete
User->getBoardList, getBoardDetail, searchBoardList

그 외 메서드는 서비스단 내에서 사용하는 메서드이므로 따로 권한은 안주셔도 됩니다.

File쪽은 다른곳에서도 많이 쓸것 같아서 따로 global에 유틸로 빼두었는데
그 중에서 NoticeFileService 단에서는
전부 Admin 권한 달아주시면 될거 같습니다

Calendar쪽 EventService.java
Admin->createSchedule, updateSchedule, deleteSchedule
User->getScheduleList, joinSchedule, cancelSchedule

-------------
위는 3조 요구사항입니다.
전부 권한처리 완료했습니다.
